### PR TITLE
Create RequestLeave and CheckLeave entities with leave approval/rejec…

### DIFF
--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/controller/CheckLeaveController.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/controller/CheckLeaveController.java
@@ -1,0 +1,41 @@
+package com.EMS.Employee.Management.System.controller;
+
+import com.EMS.Employee.Management.System.dto.CheckLeaveDTO;
+import com.EMS.Employee.Management.System.entity.LeaveStatus;
+import com.EMS.Employee.Management.System.service.CheckLeaveService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/shiftly/ems/admin/check-leave")
+@CrossOrigin
+public class CheckLeaveController {
+
+    private final CheckLeaveService checkLeaveService;
+
+    @Autowired
+    public CheckLeaveController(CheckLeaveService checkLeaveService) {
+        this.checkLeaveService = checkLeaveService;
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<CheckLeaveDTO>> getAllLeaveChecks() {
+        List<CheckLeaveDTO> checkLeaveDTOList = checkLeaveService.getAll();
+        return ResponseEntity.ok(checkLeaveDTOList);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CheckLeaveDTO> getLeaveById(@PathVariable int id) {
+        return checkLeaveService.getLeaveById(id);
+    }
+
+    @PutMapping("/update-status/{id}")
+    public ResponseEntity<CheckLeaveDTO> updateLeaveStatus(
+            @PathVariable int id,
+            @RequestParam LeaveStatus newStatus) {
+        return checkLeaveService.updateLeaveStatus(id, newStatus);
+    }
+}

--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/controller/RequestLeaveController.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/controller/RequestLeaveController.java
@@ -1,0 +1,48 @@
+package com.EMS.Employee.Management.System.controller;
+
+import com.EMS.Employee.Management.System.dto.RequestLeaveDTO;
+import com.EMS.Employee.Management.System.service.RequestLeaveService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/shiftly/ems/leave")
+@CrossOrigin
+public class RequestLeaveController {
+
+    @Autowired
+    private RequestLeaveService requestLeaveService;
+
+
+    @PostMapping("/add")
+    public ResponseEntity<RequestLeaveDTO> addLeave(@RequestBody RequestLeaveDTO requestLeaveDTO) {
+        return requestLeaveService.addLeave(requestLeaveDTO);
+    }
+
+
+    @GetMapping("/all")
+    public List<RequestLeaveDTO> getAllLeaves() {
+        return requestLeaveService.getAllLeaves();
+    }
+
+
+    @GetMapping("/{id}")
+    public ResponseEntity<RequestLeaveDTO> getLeaveById(@PathVariable int id) {
+        return requestLeaveService.getLeaveById(id);
+    }
+
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<RequestLeaveDTO> deleteLeaveById(@PathVariable int id) {
+        return requestLeaveService.deleteLeaveById(id);
+    }
+
+
+    @PutMapping("/update/{id}")
+    public ResponseEntity<RequestLeaveDTO> updateLeaveById(@PathVariable int id, @RequestBody RequestLeaveDTO requestLeaveDTO) {
+        return requestLeaveService.updateLeaveById(requestLeaveDTO, id);
+    }
+}

--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/dto/CheckLeaveDTO.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/dto/CheckLeaveDTO.java
@@ -1,0 +1,18 @@
+package com.EMS.Employee.Management.System.dto;
+
+import com.EMS.Employee.Management.System.entity.LeaveStatus;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CheckLeaveDTO {
+    private int checkId;
+    private int leaveId;
+    private LeaveStatus status;
+    private int adminId;
+    private String adminName;
+    private RequestLeaveDTO requestLeaveDTO;  // Add the RequestLeaveDTO to include all request leave data
+}

--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/dto/RequestLeaveDTO.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/dto/RequestLeaveDTO.java
@@ -1,0 +1,25 @@
+package com.EMS.Employee.Management.System.dto;
+
+import com.EMS.Employee.Management.System.entity.LeaveStatus;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestLeaveDTO {
+
+    private int leaveId;
+    private int userId;
+    private String userName;
+    private String leaveType;
+    private String leaveFrom;
+    private String leaveTo;
+    private int duration;
+    private String coverPerson;
+    private String reportTo;
+    private String reason;
+    private LeaveStatus status;
+}
+

--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/entity/CheckLeaveEntity.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/entity/CheckLeaveEntity.java
@@ -1,0 +1,37 @@
+package com.EMS.Employee.Management.System.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "check_leaves")
+public class CheckLeaveEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "check_id")
+    private int checkId;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leave_id", referencedColumnName = "leave_id")
+    private RequestLeaveEntity requestLeave;
+
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "leave_status")
+    private LeaveStatus status = LeaveStatus.PENDING;
+
+    @Column(name = "admin_id")
+    private int adminId;
+
+    @Column(name = "admin_name")
+    private String adminName;
+
+
+}

--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/entity/LeaveStatus.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/entity/LeaveStatus.java
@@ -1,0 +1,7 @@
+package com.EMS.Employee.Management.System.entity;
+
+public enum LeaveStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/entity/RequestLeaveEntity.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/entity/RequestLeaveEntity.java
@@ -1,0 +1,53 @@
+package com.EMS.Employee.Management.System.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "request_leaves")
+public class RequestLeaveEntity {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "leave_id")
+        private int leaveId;
+
+        @Column(name = "user_id")
+        private int userId;
+
+        @Column(name = "user_name")
+        private String userName;
+
+        @Column(name = "leave_type")
+        private String leaveType;
+
+        @Column(name = "leave_from")
+        private String leaveFrom;
+
+        @Column(name = "leave_to")
+        private String leaveTo;
+
+        @Column(name = "duration_days")
+        private int duration;
+
+        @Column(name = "cover_person")
+        private String coverPerson;
+
+        @Column(name = "report_to")
+        private String reportTo;
+
+        @Column(name = "reason_for_leave")
+        private String reason;
+
+
+        @Enumerated(EnumType.STRING)
+        @Column(name = "leave_status")
+        private LeaveStatus status = LeaveStatus.PENDING;
+
+
+}

--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/repo/CheckLeaveRepo.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/repo/CheckLeaveRepo.java
@@ -1,0 +1,9 @@
+package com.EMS.Employee.Management.System.repo;
+
+import com.EMS.Employee.Management.System.entity.CheckLeaveEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CheckLeaveRepo extends JpaRepository<CheckLeaveEntity , Integer> {
+}

--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/repo/RequestLeaveRepo.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/repo/RequestLeaveRepo.java
@@ -1,0 +1,9 @@
+package com.EMS.Employee.Management.System.repo;
+
+import com.EMS.Employee.Management.System.entity.RequestLeaveEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RequestLeaveRepo extends JpaRepository<RequestLeaveEntity , Integer> {
+}

--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/service/CheckLeaveService.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/service/CheckLeaveService.java
@@ -1,0 +1,16 @@
+package com.EMS.Employee.Management.System.service;
+
+import com.EMS.Employee.Management.System.dto.CheckLeaveDTO;
+import com.EMS.Employee.Management.System.entity.LeaveStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+public interface CheckLeaveService{
+
+    public List<CheckLeaveDTO> getAll();
+
+    public ResponseEntity<CheckLeaveDTO> getLeaveById(int id);
+
+    public ResponseEntity<CheckLeaveDTO> updateLeaveStatus(int id , LeaveStatus leaveStatus);
+}

--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/service/RequestLeaveService.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/service/RequestLeaveService.java
@@ -1,0 +1,20 @@
+package com.EMS.Employee.Management.System.service;
+
+import com.EMS.Employee.Management.System.dto.RequestLeaveDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+public interface RequestLeaveService {
+
+    public List<RequestLeaveDTO> getAllLeaves();
+
+    public ResponseEntity<RequestLeaveDTO> addLeave(RequestLeaveDTO requestLeaveDTO);
+
+    public ResponseEntity<RequestLeaveDTO> deleteLeaveById(int id);
+
+    public ResponseEntity<RequestLeaveDTO> updateLeaveById(RequestLeaveDTO requestLeaveDTO , int id);
+
+    public ResponseEntity<RequestLeaveDTO> getLeaveById(int id);
+}

--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/service/impl/CheckLeaveServiceImpl.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/service/impl/CheckLeaveServiceImpl.java
@@ -1,0 +1,105 @@
+package com.EMS.Employee.Management.System.service.impl;
+
+import com.EMS.Employee.Management.System.dto.CheckLeaveDTO;
+import com.EMS.Employee.Management.System.dto.RequestLeaveDTO;
+import com.EMS.Employee.Management.System.entity.CheckLeaveEntity;
+import com.EMS.Employee.Management.System.entity.LeaveStatus;
+import com.EMS.Employee.Management.System.entity.RequestLeaveEntity;
+import com.EMS.Employee.Management.System.repo.CheckLeaveRepo;
+import com.EMS.Employee.Management.System.repo.RequestLeaveRepo;
+import com.EMS.Employee.Management.System.service.CheckLeaveService;
+import org.springframework.beans.BeanUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class CheckLeaveServiceImpl implements CheckLeaveService {
+
+    private final CheckLeaveRepo checkLeaveRepo;
+    private final RequestLeaveRepo requestLeaveRepo;
+
+    public CheckLeaveServiceImpl(CheckLeaveRepo checkLeaveRepo, RequestLeaveRepo requestLeaveRepo) {
+        this.checkLeaveRepo = checkLeaveRepo;
+        this.requestLeaveRepo = requestLeaveRepo;
+    }
+
+    @Override
+    public List<CheckLeaveDTO> getAll() {
+        List<CheckLeaveEntity> checkLeaveEntities = checkLeaveRepo.findAll();
+        return checkLeaveEntities.stream()
+                .map(checkLeaveEntity -> {
+                    // Create CheckLeaveDTO from CheckLeaveEntity
+                    CheckLeaveDTO checkLeaveDTO = new CheckLeaveDTO();
+                    BeanUtils.copyProperties(checkLeaveEntity, checkLeaveDTO);
+
+                    // Get the RequestLeaveEntity and map it to RequestLeaveDTO
+                    RequestLeaveEntity requestLeave = checkLeaveEntity.getRequestLeave();
+                    RequestLeaveDTO requestLeaveDTO = new RequestLeaveDTO();
+                    BeanUtils.copyProperties(requestLeave, requestLeaveDTO);
+
+                    // Set the RequestLeaveDTO in CheckLeaveDTO
+                    checkLeaveDTO.setRequestLeaveDTO(requestLeaveDTO);
+                    return checkLeaveDTO;
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public ResponseEntity<CheckLeaveDTO> getLeaveById(int id) {
+        Optional<CheckLeaveEntity> checkLeave = checkLeaveRepo.findById(id);
+        if (checkLeave.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new CheckLeaveDTO()); // return empty or error response
+        }
+
+        CheckLeaveEntity checkLeaveEntity = checkLeave.get();
+        CheckLeaveDTO checkLeaveDTO = new CheckLeaveDTO();
+        BeanUtils.copyProperties(checkLeaveEntity, checkLeaveDTO);
+
+        // Map RequestLeaveEntity to RequestLeaveDTO
+        RequestLeaveEntity requestLeave = checkLeaveEntity.getRequestLeave();
+        RequestLeaveDTO requestLeaveDTO = new RequestLeaveDTO();
+        BeanUtils.copyProperties(requestLeave, requestLeaveDTO);
+
+        // Set RequestLeaveDTO in CheckLeaveDTO
+        checkLeaveDTO.setRequestLeaveDTO(requestLeaveDTO);
+
+        return ResponseEntity.ok(checkLeaveDTO);
+    }
+
+    @Override
+    public ResponseEntity<CheckLeaveDTO> updateLeaveStatus(int id, LeaveStatus leaveStatus) {
+        Optional<CheckLeaveEntity> checkLeave = checkLeaveRepo.findById(id);
+        if (checkLeave.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new CheckLeaveDTO()); // return empty or error response
+        }
+
+        CheckLeaveEntity checkLeaveEntity = checkLeave.get();
+        checkLeaveEntity.setStatus(leaveStatus);
+
+        // Update the corresponding RequestLeaveEntity status
+        RequestLeaveEntity requestLeave = checkLeaveEntity.getRequestLeave();
+        requestLeave.setStatus(leaveStatus);  // Update RequestLeave status
+
+        requestLeaveRepo.save(requestLeave);  // Save updated RequestLeaveEntity
+        checkLeaveRepo.save(checkLeaveEntity);  // Save updated CheckLeaveEntity
+
+        CheckLeaveDTO checkLeaveDTO = new CheckLeaveDTO();
+        BeanUtils.copyProperties(checkLeaveEntity, checkLeaveDTO);
+
+        // Map RequestLeaveEntity to RequestLeaveDTO
+        RequestLeaveDTO requestLeaveDTO = new RequestLeaveDTO();
+        BeanUtils.copyProperties(requestLeave, requestLeaveDTO);
+
+        // Set RequestLeaveDTO in CheckLeaveDTO
+        checkLeaveDTO.setRequestLeaveDTO(requestLeaveDTO);
+
+        return ResponseEntity.ok(checkLeaveDTO);
+    }
+}

--- a/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/service/impl/RequestLeaveServiceImpl.java
+++ b/Employee-Management-System/src/main/java/com/EMS/Employee/Management/System/service/impl/RequestLeaveServiceImpl.java
@@ -1,0 +1,158 @@
+package com.EMS.Employee.Management.System.service.impl;
+
+import com.EMS.Employee.Management.System.dto.RequestLeaveDTO;
+import com.EMS.Employee.Management.System.entity.CheckLeaveEntity;
+import com.EMS.Employee.Management.System.entity.LeaveStatus;
+import com.EMS.Employee.Management.System.entity.RequestLeaveEntity;
+import com.EMS.Employee.Management.System.repo.CheckLeaveRepo;
+import com.EMS.Employee.Management.System.repo.RequestLeaveRepo;
+import com.EMS.Employee.Management.System.service.RequestLeaveService;
+import org.springframework.beans.BeanUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class RequestLeaveServiceImpl implements RequestLeaveService {
+
+    private final RequestLeaveRepo requestLeaveRepo;
+    private final CheckLeaveRepo checkLeaveRepo;
+
+    public RequestLeaveServiceImpl(RequestLeaveRepo requestLeaveRepo, CheckLeaveRepo checkLeaveRepo) {
+        this.requestLeaveRepo = requestLeaveRepo;
+        this.checkLeaveRepo = checkLeaveRepo;
+    }
+
+    @Override
+    public List<RequestLeaveDTO> getAllLeaves() {
+
+        List<RequestLeaveEntity> requestLeaveEntities = requestLeaveRepo.findAll();
+
+        List<RequestLeaveDTO> requestLeaveDTOs = requestLeaveEntities
+                .stream().map(requestLeaveEntity -> new RequestLeaveDTO(
+                        requestLeaveEntity.getLeaveId(),
+                        requestLeaveEntity.getUserId(),
+                        requestLeaveEntity.getUserName(),
+                        requestLeaveEntity.getLeaveType(),
+                        requestLeaveEntity.getLeaveFrom(),
+                        requestLeaveEntity.getLeaveTo(),
+                        requestLeaveEntity.getDuration(),
+                        requestLeaveEntity.getCoverPerson(),
+                        requestLeaveEntity.getReportTo(),
+                        requestLeaveEntity.getReason(),
+                        requestLeaveEntity.getStatus()
+                ))
+                .collect(Collectors.toList());
+
+        return requestLeaveDTOs;
+    }
+
+    @Override
+    public ResponseEntity<RequestLeaveDTO> addLeave(RequestLeaveDTO requestLeaveDTO) {
+        RequestLeaveEntity requestLeaveEntity = new RequestLeaveEntity();
+
+        BeanUtils.copyProperties(requestLeaveDTO, requestLeaveEntity);
+
+        RequestLeaveEntity savedEntity = requestLeaveRepo.save(requestLeaveEntity);
+
+        // Create CheckLeaveEntity and link it to the saved RequestLeaveEntity
+        CheckLeaveEntity checkLeaveEntity = new CheckLeaveEntity();
+        checkLeaveEntity.setRequestLeave(savedEntity);
+        checkLeaveEntity.setStatus(LeaveStatus.PENDING);  // Set initial status to PENDING
+        checkLeaveEntity.setAdminId(0);  // Set a default adminId, adjust as needed
+        checkLeaveEntity.setAdminName("Admin");  // Set a default adminName, adjust as needed
+
+        // Save CheckLeaveEntity
+        checkLeaveRepo.save(checkLeaveEntity);
+
+        RequestLeaveDTO savedDTO = new RequestLeaveDTO();
+        BeanUtils.copyProperties(savedEntity, savedDTO);
+
+        return ResponseEntity.ok(savedDTO);
+    }
+
+    @Override
+    public ResponseEntity<RequestLeaveDTO> deleteLeaveById(int id) {
+
+        Optional<RequestLeaveEntity> requestLeave = requestLeaveRepo.findById(id);
+
+        if (requestLeave.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        } else {
+            RequestLeaveDTO requestLeaveDTO = new RequestLeaveDTO();
+            BeanUtils.copyProperties(requestLeave.get(), requestLeaveDTO);
+            requestLeaveRepo.deleteById(id);
+            return ResponseEntity.ok(requestLeaveDTO);
+        }
+    }
+
+    @Override
+    public ResponseEntity<RequestLeaveDTO> updateLeaveById(RequestLeaveDTO requestLeaveDTO, int id) {
+
+        Optional<RequestLeaveEntity> leave = requestLeaveRepo.findById(id);
+
+        if (leave.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+
+        RequestLeaveEntity requestLeave = leave.get();
+
+        // Updating the RequestLeaveEntity fields based on the incoming DTO values
+        if (requestLeaveDTO.getUserId() != 0) {
+            requestLeave.setUserId(requestLeaveDTO.getUserId());
+        }
+        if (requestLeaveDTO.getUserName() != null && !requestLeaveDTO.getUserName().isEmpty()) {
+            requestLeave.setUserName(requestLeaveDTO.getUserName());
+        }
+        if (requestLeaveDTO.getLeaveType() != null && !requestLeaveDTO.getLeaveType().isEmpty()) {
+            requestLeave.setLeaveType(requestLeaveDTO.getLeaveType());
+        }
+        if (requestLeaveDTO.getLeaveFrom() != null && !requestLeaveDTO.getLeaveFrom().isEmpty()) {
+            requestLeave.setLeaveFrom(requestLeaveDTO.getLeaveFrom());
+        }
+        if (requestLeaveDTO.getLeaveTo() != null && !requestLeaveDTO.getLeaveTo().isEmpty()) {
+            requestLeave.setLeaveTo(requestLeaveDTO.getLeaveTo());
+        }
+        if (requestLeaveDTO.getDuration() != 0) {
+            requestLeave.setDuration(requestLeaveDTO.getDuration());
+        }
+        if (requestLeaveDTO.getCoverPerson() != null && !requestLeaveDTO.getCoverPerson().isEmpty()) {
+            requestLeave.setCoverPerson(requestLeaveDTO.getCoverPerson());
+        }
+        if (requestLeaveDTO.getReportTo() != null && !requestLeaveDTO.getReportTo().isEmpty()) {
+            requestLeave.setReportTo(requestLeaveDTO.getReportTo());
+        }
+        if (requestLeaveDTO.getReason() != null && !requestLeaveDTO.getReason().isEmpty()) {
+            requestLeave.setReason(requestLeaveDTO.getReason());
+        }
+        if (requestLeaveDTO.getStatus() != null) {
+            requestLeave.setStatus(requestLeaveDTO.getStatus());
+        }
+
+        // Save the updated leave entity
+        requestLeaveRepo.save(requestLeave);
+
+        BeanUtils.copyProperties(requestLeave, requestLeaveDTO);
+
+        return ResponseEntity.ok(requestLeaveDTO);
+    }
+
+    @Override
+    public ResponseEntity<RequestLeaveDTO> getLeaveById(int id) {
+
+        Optional<RequestLeaveEntity> requestLeave = requestLeaveRepo.findById(id);
+
+        if (requestLeave.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+
+        RequestLeaveDTO requestLeaveDTO = new RequestLeaveDTO();
+        BeanUtils.copyProperties(requestLeave.get(), requestLeaveDTO);
+
+        return ResponseEntity.ok(requestLeaveDTO);
+    }
+}


### PR DESCRIPTION
…tion functionality

- Created `RequestLeaveEntity` to represent employee leave requests with fields such as `userId`, `leaveType`, `leaveFrom`, `leaveTo`, `status`, etc.
- Created `CheckLeaveEntity` to represent the leave status check, linking `RequestLeaveEntity` with fields such as `adminId`, `adminName`, and `leave_status`.
- Implemented CRUD operations for `RequestLeave` (add, update, delete) and leave review functionality (approve/reject).
- Updated controllers to handle leave requests and leave checks using the `RequestLeaveService` and `CheckLeaveService`.
- Added `LeaveStatus` enum to represent leave statuses (`PENDING`, `APPROVED`, `REJECTED`).